### PR TITLE
fix: labels prompt text parsing

### DIFF
--- a/components/create-question-form/create-question-form.tsx
+++ b/components/create-question-form/create-question-form.tsx
@@ -72,10 +72,7 @@ export default function CreateQuestionForm() {
         numberOfQuestions: data.numberOfQuestions,
         type: data.type,
         difficulty: data.difficulty,
-        labels:
-          tags.length > 0
-            ? JSON.stringify(tags.map((tag) => tag.text))
-            : undefined,
+        labels: tags.length > 0 ? tags.map((tag) => tag.text) : undefined,
       };
 
       postQuestion({ data: payload, isJson: true });


### PR DESCRIPTION
This pull request includes a small change to the `CreateQuestionForm` component to simplify the handling of tags when creating a new question.

* [`components/create-question-form/create-question-form.tsx`](diffhunk://#diff-347e892c3643303fc012b3a6900002652bb152b1d20f12a342960067931214b5L75-R75): Modified the `labels` property to directly map tags to their text values without converting them to a JSON string.